### PR TITLE
Add project documentation: architecture, conventions, and decision templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Magyar Otthon — Project Constitution
+
+A family Hungarian language learning PWA. The goal is natural, daily language use between a parent and their children and partner, not academic study.
+
+## What this app is
+
+- Phrase-based lessons organised by daily-life situations (morning, outings, food, bedtime, etc.)
+- Quiz engine that reinforces weak phrases and adapts to time of day
+- Deployed as a mobile-first PWA to GitHub Pages; used offline
+
+## What this app is not
+
+- A general-purpose language course
+- Multi-user / server-connected
+- Monetised
+
+## Key files
+
+| Path | Purpose |
+|------|---------|
+| `src/App.jsx` | Entire app — data, logic, and UI (single file by design) |
+| `public/manifest.json` | PWA manifest |
+| `vite.config.js` | Build config; `base` must match GitHub Pages path |
+| `docs/architecture.md` | Deeper architecture notes |
+| `docs/conventions.md` | Coding standards |
+| `docs/specs/` | One spec file per planned feature |
+| `docs/decisions/` | Lightweight ADRs |
+
+## Working with Claude
+
+1. **Before implementing a feature**, write a spec in `docs/specs/` using `_template.md` and get approval.
+2. **Reference the spec** throughout implementation; check off tasks as they complete.
+3. **Don't split `App.jsx`** into multiple files without a decision record in `docs/decisions/`.
+4. **Don't add dependencies** without discussing trade-offs first; the app is intentionally zero-dependency beyond React and Vite.
+
+## Deploy
+
+```bash
+npm run deploy   # builds and pushes to gh-pages branch
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+## Overview
+
+Magyar Otthon is a **single-file React app**. All lesson data, business logic, and UI live in `src/App.jsx`. This is intentional — the app is small, the deployment target is a static host, and keeping everything in one file makes offline reading and AI-assisted editing straightforward.
+
+## Data model
+
+```
+PHASES[]          — 8 thematic groups (Morning, Going Out, Playing, …)
+LESSONS[]         — 35+ lesson objects, each belonging to one phase
+  └─ phrases[]    — array of { hu, pr, en } (Hungarian, pronunciation, English)
+```
+
+Each lesson also has:
+- `aud` — target audience: `"kids"` or `"wife"`
+- `tip` — a short teaching note
+- `pat` — optional grammar pattern note
+
+## State
+
+All runtime state lives in two places:
+
+| Location | What |
+|----------|------|
+| React `useState` | UI state — current screen, selected lesson, active question, etc. |
+| `localStorage` | Persisted stats via the `useStats` hook |
+
+`useStats` exposes: `recordPhrase`, `recordSession`, `startTimer`, `stopTimer`, `getWeakPhrases`, `setDailyGoal`.
+
+Stats schema (key: `"magyarStats"`):
+```js
+{
+  totalTime,       // seconds
+  dailyTime,       // { "Mon Jan 01 2025": seconds }
+  streakDays,      // ["Mon Jan 01 2025", …]
+  lessonScores,    // { lessonId: { best, attempts } }
+  phraseScores,    // { huText: { right, wrong } }
+  dailyGoal,       // minutes
+}
+```
+
+## Daily Focus Engine
+
+`getDailyFocus(stats)` scores every lesson based on:
+1. **Time of day** — `TIME_TAGS` maps hour ranges to lesson IDs
+2. **Day of week** — `WEEKEND_BOOST` / `WEEKDAY_BOOST` arrays
+3. **Weakness** — phrase error rate from `phraseScores`
+4. **Recency** — lessons not recently attempted score higher
+
+Returns the top-scored lesson and a human-readable reason string.
+
+## Quiz engine
+
+`generateQuestions(lesson, weakPhrases, count)` produces a mixed question set from six types:
+
+| Type | Description |
+|------|-------------|
+| `mc_en_hu` | English prompt → pick Hungarian |
+| `mc_hu_en` | Hungarian prompt → pick English |
+| `type` | English prompt → type Hungarian |
+| `tf` | Hungarian prompt → true/false English match |
+| `fill` | English prompt → fill missing word in Hungarian sentence |
+| `match` | Match 4 pairs (shown as a pairing UI) |
+
+Weak phrases (wrong > 0) are over-represented in the pool.
+
+## Speech
+
+`speakHu(text)` uses the Web Speech API (`SpeechSynthesisUtterance`, `lang="hu-HU"`, `rate=0.85`). Falls back silently if unavailable.
+
+## Feedback
+
+`FeedbackModal` posts directly to the GitHub Issues API (`tomrook12/statichungarianapp`) with a category and description. No backend required.
+
+## Navigation model
+
+Single-page, screen-based navigation managed with a `view` state string:
+
+```
+"home" → "phases" → "lessons" → "lesson" → "quiz" → "result"
+                                          → "stats"
+```
+
+No router library; `onBack` callbacks walk back up the stack.
+
+## Build & deploy
+
+- `vite build` — outputs to `dist/`
+- `vite.config.js` `base: '/StaticHungarianApp/'` must match the GitHub Pages sub-path
+- `npm run deploy` — runs `vite build && gh-pages -d dist`

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,53 @@
+# Conventions
+
+## File structure
+
+The app is intentionally a single file (`src/App.jsx`). Sections are separated with ASCII banner comments:
+
+```js
+// ─── SECTION NAME ──────────────────────────────────────────────────────────
+```
+
+Maintain this order: DATA → UTILITIES → ENGINES → HOOKS → QUESTION GENERATORS → STYLES → COMPONENTS → APP.
+
+## Data
+
+- Lesson `id` values are stable and used as keys in `localStorage`. Never reuse or renumber them.
+- Add new lessons by appending to `LESSONS[]` with the next sequential `id`.
+- Phrase fields: `hu` (Hungarian text), `pr` (pronunciation guide), `en` (English translation). All three are required.
+- `aud` is either `"kids"` or `"wife"`. Omitting it is acceptable only for toolkit/reference lessons.
+
+## Components
+
+- Inline styles only — no CSS files, no CSS-in-JS libraries, no Tailwind.
+- All colours come from the `C` constants object. Never hardcode a colour outside of `C`.
+- Components are functions, not classes.
+- Keep components small and co-located in the file. Extract a component when JSX is repeated more than twice.
+
+## State
+
+- Prefer `useState` for UI state, `useCallback` for stable handlers, `useMemo` for derived values.
+- All persisted state goes through `useStats`. Don't call `localStorage` directly anywhere else.
+- Don't add a new top-level state manager (Redux, Zustand, etc.) without a decision record.
+
+## Naming
+
+- React components: `PascalCase`
+- Functions and variables: `camelCase`
+- Constants (data arrays, config objects): `SCREAMING_SNAKE_CASE`
+- Inline style objects defined at call-site need no naming convention.
+
+## Questions / quiz
+
+- Every question generator (`gen*`) accepts a phrase object and returns a question object with at least `{ type, answer, phrase }`.
+- `generateQuestions` is the only place that calls question generators. Don't call them directly from components.
+
+## Accessibility & mobile
+
+- The app targets portrait mobile. Default touch target minimum is 44 × 44 px.
+- No hover-only interactions.
+- Speech buttons are supplementary; the app must be fully usable without audio.
+
+## Dependencies
+
+Zero production dependencies beyond `react` and `react-dom`. Adding a dependency requires a decision record explaining why the bundle cost is justified.

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,23 @@
+# Decision: [Short title]
+
+> **Date:** YYYY-MM-DD
+> **Status:** Proposed | Accepted | Superseded by [link]
+
+## Context
+
+What situation forced this decision? What constraints existed?
+
+## Decision
+
+What we decided to do, stated plainly.
+
+## Alternatives considered
+
+| Option | Why rejected |
+|--------|-------------|
+| Option A | ... |
+| Option B | ... |
+
+## Consequences
+
+What becomes easier or harder as a result of this decision?

--- a/docs/specs/_template.md
+++ b/docs/specs/_template.md
@@ -1,0 +1,52 @@
+# Spec: [Feature Name]
+
+> **Status:** Draft | Approved | In Progress | Done
+> **Branch:** `feature/...`
+
+## Goal
+
+One or two sentences. What problem does this solve, and for whom?
+
+## Background
+
+Why now? Any context Claude needs to understand the motivation.
+
+## Requirements
+
+### Must have
+- [ ] ...
+
+### Nice to have
+- [ ] ...
+
+### Out of scope
+- ...
+
+## Design
+
+Describe the approach at a high level. Include:
+- Which existing data structures or components are affected
+- Any new state required and where it lives
+- Key UI interactions or flows
+
+Sketches / ASCII diagrams are welcome.
+
+## Implementation tasks
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+- [ ] Update `docs/architecture.md` if the architecture changes
+- [ ] Add a decision record in `docs/decisions/` if any significant trade-off was made
+
+## Open questions
+
+- Question 1 — *owner, target date*
+- Question 2
+
+## Acceptance criteria
+
+How will we know this is done and working correctly?
+
+- [ ] Criterion 1
+- [ ] Criterion 2


### PR DESCRIPTION
## Summary

This PR establishes a comprehensive documentation framework for the Magyar Otthon project. It adds foundational guides that explain the app's architecture, coding conventions, and decision-making process, along with templates for future feature specs and architectural decisions.

## Changes

- **`CLAUDE.md`** — Project constitution outlining what the app is/isn't, key files, and guidelines for working with Claude on features
- **`docs/architecture.md`** — Deep dive into the single-file React architecture, data model, state management, daily focus engine, quiz engine, speech synthesis, and deployment
- **`docs/conventions.md`** — Coding standards covering file structure, data naming, component patterns, state management, accessibility, and dependency policy
- **`docs/specs/_template.md`** — Template for writing feature specifications with status, requirements, design, tasks, and acceptance criteria
- **`docs/decisions/_template.md`** — Lightweight ADR template for recording significant architectural or trade-off decisions

## Implementation notes

- All documentation is written to support AI-assisted development and future maintenance
- The architecture doc reflects the intentional single-file design and explains the rationale
- Conventions doc enforces zero production dependencies beyond React and Vite
- Templates are ready for use in future feature work and design decisions
- No code changes to the app itself; this is purely documentation infrastructure

https://claude.ai/code/session_01JDDNXLAd87LbhuSXDxS9EP