### PR TITLE
fix: correct Vite base path and manifest start_url for GitHub Pages

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Magyar Otthon",
   "short_name": "Magyar",
   "description": "Family Hungarian learning app",
-  "start_url": "/magyar-otthon/",
+  "start_url": "/MagyarOtthon/",
   "display": "standalone",
   "background_color": "#0F1117",
   "theme_color": "#0F1117",

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/StaticHungarianApp/',
+  base: '/MagyarOtthon/',
 })


### PR DESCRIPTION
- vite.config.js: change base from '/StaticHungarianApp/' to '/MagyarOtthon/'
- manifest.json: change start_url from '/magyar-otthon/' to '/MagyarOtthon/'

https://claude.ai/code/session_01C454UgPMHUrFZG4p5tSjJ8