### PR TITLE
Dissolve Phase 9 Grammar Spine into everyday phases 1–8

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,8 +7,8 @@ Magyar Otthon is a **single-file React app**. All lesson data, business logic, a
 ## Data model
 
 ```
-PHASES[]          — 9 thematic groups (Morning, Going Out, …, Grammar Spine)
-LESSONS[]         — 51+ lesson objects, each belonging to one phase
+PHASES[]          — 8 thematic groups (Morning, Going Out, Playing, Food, Reading, Bath & Bed, End of Day, Toolkit)
+LESSONS[]         — 55 lesson objects, each belonging to one phase
   └─ phrases[]    — array of { hu, pr, en } (Hungarian, pronunciation, English)
 ```
 
@@ -16,7 +16,7 @@ Each lesson also has:
 - `aud` — target audience: `"kids"`, `"wife"`, or `"both"`
 - `tip` — a short teaching note
 - `pat` — optional grammar pattern note; if it contains `\n`, it is rendered as `<pre>`-style preformatted text in the lesson view so paradigm tables stay aligned
-- `patternId` — optional string tag naming the grammar paradigm the lesson drills (e.g. `"past-indef"`, `"dative"`, `"conditional"`). Present only on Phase 9 Grammar Spine lessons (ids 45–56). Existing lessons without this field are unaffected.
+- `patternId` — optional string tag naming the grammar paradigm the lesson drills (e.g. `"past-indef"`, `"dative"`, `"conditional"`). Present on paradigm-anchored lessons (ids 45–56 and the merged lesson 32), which are distributed across phases 1–8 rather than collected in a dedicated phase. Lessons without this field are unaffected.
 
 ## State
 

--- a/docs/decisions/grammar-dissolved-into-everyday-phases.md
+++ b/docs/decisions/grammar-dissolved-into-everyday-phases.md
@@ -1,0 +1,64 @@
+# Decision: Grammar Spine dissolved into everyday phases
+
+> **Date:** 2026-04-10
+> **Status:** Accepted
+> **Supersedes:** `grammar-via-curated-lessons.md` (2026-04-07)
+
+## Context
+
+On 2026-04-07 we added a Phase 9 "Grammar Spine" — 12 curated phrase lessons (ids 45–56) each anchored to a grammar paradigm (past tense, conditional, dative, possessives, prefixes, comparison…). The intent was to close a B1 gap identified by the CEFR analysis without breaking the app's phrase-based constitution.
+
+In daily use, the separate phase turned out to create a visual and conceptual "grammar corner" in the home screen at odds with the constitution: *"phrase-based lessons organised by daily-life situations… not academic study"*. The content of the 12 lessons is good — the phrases are natural family utterances and the paradigm tables are useful — but packaging them behind their own phase header subtly re-introduces the "grammar tab" pattern the original decision explicitly rejected.
+
+## Decision
+
+Dissolve Phase 9. Relocate lessons 45–56 into the existing everyday phases (1–8) with everyday-themed titles, so a learner encounters the conditional inside Food ("I Would Like…"), imperatives inside Playing ("Come Here! Go Back!"), past tense inside End of Day ("What Everyone Did Today"), and so on. Lesson 47 "Past Tense — Talking About Yesterday" merges into lesson 32 "Their Day" since both cover the same evening conversation; the other 11 become new everyday-titled lessons in their target phase.
+
+Preserved:
+- **Lesson ids 45–56.** Stats persistence (`stats.lessonScores`, keyed by numeric id) and `stats.phraseScores` (keyed by `p.hu`) stay attached to the same lessons the learner has already drilled.
+- **All Hungarian phrase text, pronunciations, English translations.** No rewriting.
+- **All `pat` paradigm tables.** The Pattern: card renderer is already phase-agnostic (`src/App.jsx:1065`, `whiteSpace:"pre-wrap"`) and the tables carry real teaching value.
+- **The `patternId` field on every relocated lesson.** Additive, harmless, and required by follow-up specs (`engine-depth.md` drill-by-pattern, `plans-hypotheticals.md`).
+
+## Mapping
+
+| id | New title | Phase | Source lesson |
+|---|---|---|---|
+| 45 | Reading the Book vs a Book | 5 Reading | Definite vs Indefinite Verbs |
+| 46 | What Everyone Did Today | 7 End of Day | Past Tense — Full Paradigm |
+| 47 | *(merged into lesson 32 Their Day)* | 7 End of Day | Past Tense — Talking About Yesterday |
+| 48 | I Would Like… | 4 Food | Conditional — I Would… |
+| 49 | What We'll Do Today | 1 Morning | Future with fog |
+| 50 | Come Here! Go Back! | 3 Playing | Imperative — Asking & Telling |
+| 51 | Where's Your Shoe? | 1 Morning | Possessive Suffixes |
+| 52 | Give it to Your Sister | 3 Playing | Dative -nak/-nek |
+| 53 | Going Together | 2 Going Out | Instrumental -val/-vel |
+| 54 | Coming Home From… | 2 Going Out | From-cases -tól/-ről/-ből |
+| 55 | In, Out, Up, Down | 1 Morning | Prefixes be/ki/fel/le/át/vissza |
+| 56 | Bigger, Smaller, Best | 3 Playing | Comparison |
+
+Resulting counts per phase: Morning 10, Going Out 11, Playing 11, Food 6, Reading 5, Bath & Bed 2, End of Day 5, Toolkit 5. Total: 55 lessons (56 − 1 for the 47→32 merge).
+
+Relocated lessons are also wired into `TIME_TAGS` so the Daily Focus Engine surfaces them at natural times of day (planning in the morning, imperatives in the afternoon, past-tense reflection in the evening, etc.).
+
+## Alternatives considered
+
+| Option | Why rejected |
+|---|---|
+| Aggressive merging — fold every grammar lesson into an existing situational lesson | Discards many of the 96 paradigm phrases and dilutes the focused situational lessons. The "grammar in a box" problem reappears in reverse. |
+| Delete lessons 45–56 entirely | Throws away good B1-foundation content. The gap analysis still holds. |
+| Hide Phase 9 behind a toggle | Conceals the problem instead of fixing it. |
+| Shorten or remove the `pat` paradigm tables | Discards the primary teaching anchor. The tables only render as a small "Pattern:" card and don't dominate the lesson view. |
+
+## Consequences
+
+**Easier**
+- Constitution restored: grammar is encountered in context, inside situational phases.
+- Phase list is 8 entries again; home screen is shorter.
+- Daily Focus Engine surfaces grammar-flavoured lessons at appropriate times of day.
+- Stats and progress transfer cleanly — ids and phrase text preserved.
+
+**Harder**
+- The `LESSONS` array has non-monotonic ids (lesson 45 sits in Phase 5, lesson 49 in Phase 1, etc.). This matches existing practice (lessons 40, 42–44 were already out of numeric order).
+- A small number of relocated lessons (e.g. "In, Out, Up, Down") show a denser Pattern: card than their phase neighbours.
+- One orphaned `stats.lessonScores[47]` entry may exist in user localStorage; the stats view silently skips missing ids (`src/App.jsx:950`) so it is harmless.

--- a/docs/decisions/grammar-via-curated-lessons.md
+++ b/docs/decisions/grammar-via-curated-lessons.md
@@ -1,7 +1,9 @@
 # Decision: Grammar is taught via curated phrase lessons, not a separate grammar mode
 
 > **Date:** 2026-04-07
-> **Status:** Accepted
+> **Status:** Superseded by [`grammar-dissolved-into-everyday-phases.md`](./grammar-dissolved-into-everyday-phases.md) (2026-04-10)
+>
+> The core principle (grammar via curated phrase lessons, not a grammar mode) still holds. What changed: the 12 paradigm lessons no longer live in a dedicated Phase 9 "Grammar Spine" header — they are distributed across everyday phases 1–8 with everyday-themed titles. See the superseding decision for details.
 
 ## Context
 

--- a/docs/specs/breadth-pass.md
+++ b/docs/specs/breadth-pass.md
@@ -65,7 +65,7 @@ This milestone is a **vocabulary and domain expansion**, not a grammar or engine
 ### Out of scope
 
 - New phases (all lessons slot into existing phases 1–8)
-- Grammar paradigm lessons (covered by Grammar Spine)
+- Grammar paradigm lessons (already covered by paradigm-anchored lessons 45–56, distributed across phases 1–8)
 - Engine changes (SRS, new quiz types)
 - Audio/listening features
 - Splitting App.jsx

--- a/docs/specs/engine-depth.md
+++ b/docs/specs/engine-depth.md
@@ -41,10 +41,10 @@ The app's zero-dependency constraint is respected: browser `SpeechSynthesis` API
 
 #### Grammar-Pattern Quiz Filter
 
-- [ ] A "Drill Pattern" mode accessible from any Grammar Spine lesson
+- [ ] A "Drill Pattern" mode accessible from any lesson with a `patternId`
 - [ ] Collects all phrases across all lessons sharing the same `patternId`
 - [ ] Generates a cross-lesson quiz of up to 15 phrases using existing `generateQuestions` logic
-- [ ] Example: tapping "Drill" on the dative lesson pulls dative phrases from Grammar Spine, Reasoning, Stories, and Breadth lessons
+- [ ] Example: tapping "Drill" on "Give it to Your Sister" (lesson 52, the dative paradigm lesson) pulls dative phrases from paradigm-anchored lessons, Reasoning, Stories, and Breadth lessons
 
 ### Nice to have
 
@@ -229,7 +229,7 @@ No persistence. Recording is discarded when navigating away.
 - [ ] Tapping a story sentence reveals its English translation
 - [ ] "Read aloud" plays full story via TTS
 - [ ] Listening mode auto-plays phrases with timed English reveal
-- [ ] "Drill this pattern" button appears on Grammar Spine lessons and generates a cross-lesson quiz
+- [ ] "Drill this pattern" button appears on lessons with a `patternId` and generates a cross-lesson quiz
 - [ ] (If implemented) Reconstruct quiz type works: tiles can be reordered, correct order scores a point
 - [ ] (If implemented) Shadow mode records and plays back user audio
 - [ ] No regressions in existing flows

--- a/docs/specs/grammar-spine.md
+++ b/docs/specs/grammar-spine.md
@@ -1,6 +1,8 @@
 # Spec: Grammar Spine
 
-> **Status:** Approved
+> **Update 2026-04-10:** Phase 9 was dissolved. Lessons 45–56 still exist (same ids, same phrases, same `patternId` and `pat` paradigm tables) but now live inside everyday phases 1–8 with everyday-themed titles — e.g. "Past Tense — Full Paradigm" is now "What Everyone Did Today" in End of Day; "Conditional" is now "I Would Like…" in Food. See [`docs/decisions/grammar-dissolved-into-everyday-phases.md`](../decisions/grammar-dissolved-into-everyday-phases.md). References below to "Phase 9" and the standalone "Grammar Spine" header are historical.
+>
+> **Status:** Approved (implemented, then restructured — see update above)
 > **Branch:** `claude/review-hungarian-curriculum-inyIG`
 
 ## Goal

--- a/docs/specs/plans-hypotheticals.md
+++ b/docs/specs/plans-hypotheticals.md
@@ -10,11 +10,11 @@ Add a content phase covering future plans, wishes, conditional reasoning, and hy
 ## Background
 
 After Milestones 1 and 2, the learner has:
-- Grammar foundations (Grammar Spine): future with `fog`, conditional `-nék/-nél/-na`, imperative
+- Grammar foundations (paradigm-anchored lessons 45–56): future with `fog`, conditional `-nék/-nél/-na`, imperative
 - Reasoning connectors (Phase 10): `mert`, `ha…akkor`, `szerintem`
 - Narrative past (Phase 11): sequencing events, reported speech
 
-What's missing is *sustained use* of future and conditional in real family conversations. The Grammar Spine teaches the paradigm; Phase 10 introduces `ha…akkor`; this phase provides the extended practice needed for fluency with these structures.
+What's missing is *sustained use* of future and conditional in real family conversations. The paradigm-anchored lessons (45–56) teach the paradigm; Phase 10 introduces `ha…akkor`; this phase provides the extended practice needed for fluency with these structures.
 
 CEFR B1 descriptor: "Can describe hopes, dreams, and ambitions. Can give reasons and explanations for opinions and plans."
 
@@ -44,7 +44,7 @@ CEFR B1 descriptor: "Can describe hopes, dreams, and ambitions. Can give reasons
 
 ### Nice to have
 
-- [ ] `tip` fields reference Grammar Spine lessons for paradigm review (e.g. "See lesson 48 for full conditional endings")
+- [ ] `tip` fields reference paradigm-anchored lessons (ids 45–56) for paradigm review (e.g. "See lesson 48 'I Would Like…' for full conditional endings")
 - [ ] A "Planning Conversation" prompt card: a scenario (e.g. "Plan a birthday party") that encourages stringing multiple phrases together
 
 ### Out of scope

--- a/docs/specs/reasoning-narrative.md
+++ b/docs/specs/reasoning-narrative.md
@@ -9,7 +9,7 @@ Add two new content phases that bridge the learner from A2 to B1 by teaching the
 
 ## Background
 
-The current 44 lessons (plus 12 planned in the Grammar Spine spec) cover situational phrases for daily routines. The learner can give instructions, name objects, and handle basic social exchanges — but cannot yet:
+The current 55 lessons (including the 12 paradigm-anchored lessons 45–56, distributed across phases 1–8) cover situational phrases for daily routines. The learner can give instructions, name objects, and handle basic social exchanges — but cannot yet:
 
 - Explain *why* ("because the road is wet")
 - Express opinions with reasons ("I think we should go, because…")
@@ -17,11 +17,13 @@ The current 44 lessons (plus 12 planned in the Grammar Spine spec) cover situati
 - Report what someone said ("She said that…")
 - Connect ideas across sentences
 
-CEFR B1 requires all of these. The Grammar Spine (Milestone 1a) provides the verb/case foundations; this milestone builds discourse and pragmatics on top of that grammar.
+CEFR B1 requires all of these. The paradigm-anchored lessons (Milestone 1a, ids 45–56 distributed across phases 1–8) provide the verb/case foundations; this milestone builds discourse and pragmatics on top of that grammar.
 
 ### Phase numbering
 
-- Phase 9: Grammar Spine (Milestone 1a, already specced)
+> **Note (2026-04-10):** Phase 9 "Grammar Spine" was dissolved — its lessons now live inside phases 1–8. The phase numbers below are pre-existing draft placeholders; when implemented, they may be renumbered to start at Phase 9 now that the slot is free. See `docs/decisions/grammar-dissolved-into-everyday-phases.md`.
+
+- Milestone 1a: paradigm-anchored lessons (ids 45–56, distributed across phases 1–8)
 - **Phase 10: Reasoning & Opinion** (this spec)
 - **Phase 11: Telling Stories** (this spec)
 
@@ -51,13 +53,13 @@ CEFR B1 requires all of these. The Grammar Spine (Milestone 1a) provides the ver
 
 - [ ] Phase 10 and Phase 11 added to `PHASES` array with distinct emoji + color
 - [ ] All lessons follow existing schema: `{ id, phase, title, sub, aud, phrases[], tip, pat }`
-- [ ] All lessons include optional `patternId` field (introduced in Grammar Spine spec)
+- [ ] All lessons include optional `patternId` field (introduced by the paradigm-anchored lessons 45–56)
 - [ ] `TIME_TAGS` updated: Reasoning lessons are time-agnostic; Story lessons boosted in `evening` (bedtime storytelling context)
 - [ ] `aud` set per lesson: Reasoning lessons → `"both"`, Story lessons → mix of `"kids"` and `"wife"`
 
 ### Nice to have
 
-- [ ] Cross-references in `tip` fields pointing back to Grammar Spine lessons ("See lesson 48 for conditional paradigm")
+- [ ] Cross-references in `tip` fields pointing back to paradigm-anchored lessons ("See lesson 48 'I Would Like…' for conditional paradigm")
 - [ ] A "Conversation Builder" exercise type: given a prompt, pick 3 connected phrases in order (beyond current quiz types — could be a follow-up)
 
 ### Out of scope
@@ -98,13 +100,13 @@ Each lesson follows the existing pattern. Example:
 
 ### ID allocation
 
-Grammar Spine uses ids 45–56. This spec uses:
+Paradigm-anchored lessons use ids 45–56. This spec uses:
 - Phase 10 (Reasoning): ids **57–62**
 - Phase 11 (Stories): ids **63–68**
 
 ### Vocabulary targets
 
-Each phase adds ~100 distinct new words (connectors, abstract nouns, narrative verbs, opinion vocabulary). Combined with Grammar Spine and existing lessons, this pushes total vocabulary toward ~800–900 words.
+Each phase adds ~100 distinct new words (connectors, abstract nouns, narrative verbs, opinion vocabulary). Combined with the paradigm-anchored lessons and existing lessons, this pushes total vocabulary toward ~800–900 words.
 
 ### Grammar patterns covered
 
@@ -135,7 +137,7 @@ Each phase adds ~100 distinct new words (connectors, abstract nouns, narrative v
 
 ## Open questions
 
-- Should "Comparing Things" (Phase 10) overlap with Grammar Spine lesson 56 (Bigger, Biggest)? Recommendation: minimal overlap — Spine teaches the paradigm, this lesson teaches usage in arguments ("I think the park is better because…"). — *owner: user*
+- Should "Comparing Things" (Phase 10) overlap with paradigm-anchored lesson 56 "Bigger, Smaller, Best"? Recommendation: minimal overlap — lesson 56 teaches the paradigm, this lesson teaches usage in arguments ("I think the park is better because…"). — *owner: user*
 - Should reported speech (lesson "What She Said") cover only `hogy`-clauses, or also indirect questions (`megkérdezte, hogy…`)? Recommendation: both — they use the same `hogy` connector. — *owner: user*
 
 ## Acceptance criteria

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,15 +10,14 @@ const PHASES = [
   { id: 6, emoji: "🛁", title: "Bath & Bed", color: "#5B7FC1" },
   { id: 7, emoji: "💬", title: "End of Day", color: "#C17B3A" },
   { id: 8, emoji: "🧰", title: "Toolkit", color: "#8B8B8B" },
-  { id: 9, emoji: "🧱", title: "Grammar Spine", color: "#3AA8A8" },
 ];
 
 // Time-of-day relevance tags for the focus engine
 const TIME_TAGS = {
-  morning: [1,2,3,4,5,6,40], // Phase 1 (morning routines) + Phase 1 wife + rooms
-  midday: [7,8,9,10,11,12,13,14,21,22,23,24,25,42], // Going out + food + bikes
-  afternoon: [15,16,17,18,19,20,26,27,28,29,41,42,43,44], // Playing + reading + locations + bikes + drawing + counting
-  evening: [30,31,32,33,34,35], // Bath, bed, end of day
+  morning: [1,2,3,4,5,6,40,49,51,55], // Morning routines + rooms + plans + shoe hunt + room movement
+  midday: [7,8,9,10,11,12,13,14,21,22,23,24,25,42,48,53,54], // Going out + food + bikes + politeness + transport + coming home
+  afternoon: [15,16,17,18,19,20,26,27,28,29,41,42,43,44,50,52,56], // Playing + reading + imperatives + sharing + comparison
+  evening: [30,31,32,33,34,35,45,46], // Bath, bed, end of day + storytime + what-everyone-did
 };
 // Weekend = more playing, outings, reading; Weekday = school run, routines
 const WEEKEND_BOOST = [9,10,12,15,16,17,19,20,26,27,28,42,43,44]; // playground, library, playing, reading, bikes, drawing, counting
@@ -329,13 +328,20 @@ const LESSONS = [
       {hu:"Szép álmokat!",pr:"Sép ál-mo-kot",en:"Sweet dreams!"},
       {hu:"Szeretlek.",pr:"Se-ret-lek",en:"I love you."},
     ], tip:"Same order every night."},
-  { id:32, phase:7, title:"Their Day", sub:"What did you do · Best part", aud:"kids",
+  { id:32, phase:7, title:"Their Day", sub:"What did you do · Yesterday · Best part", aud:"kids", patternId:"past-use",
     phrases:[
       {hu:"Mit csináltál ma?",pr:"Mit chi-nál-tál mo",en:"What did you do?"},
       {hu:"Mi volt a legjobb?",pr:"Mi volt o leg-yobb",en:"What was the best part?"},
       {hu:"Kivel voltál?",pr:"Ki-vel vol-tál",en:"Who with?"},
       {hu:"Történt valami érdekes?",pr:"Tör-tént vo-lo-mi ér-de-kesh",en:"Anything interesting?"},
-    ], tip:"Two questions daily on the walk home."},
+      {hu:"Tegnap az iskolában voltam.",pr:"Teg-nop oz ish-ko-lá-bon vol-tom",en:"Yesterday I was at school."},
+      {hu:"Aludtál egyet?",pr:"O-lud-tál e-dyet",en:"Did you have a nap?"},
+      {hu:"Mentünk a parkba.",pr:"Men-tünk o pork-bo",en:"We went to the park."},
+      {hu:"Ettetek otthon?",pr:"Et-te-tek ot-hon",en:"Did you eat at home?"},
+      {hu:"Megcsináltam a házimat.",pr:"Meg-chi-nál-tom o há-zi-mot",en:"I did my homework."},
+      {hu:"Olvastunk egy könyvet.",pr:"Ol-vosh-tunk edy kön-yet",en:"We read a book."},
+      {hu:"Jól aludtál éjjel?",pr:"Yól o-lud-tál éy-yel",en:"Did you sleep well last night?"},
+    ], tip:"Two questions daily on the walk home. Try narrating what you did today — past tense becomes natural through story.", pat:"Common irregular pasts:\nvan   → volt    |  megy  → ment\nalszik → aludt  |  eszik → evett\nolvas → olvasott|  csinál → csinált"},
   { id:33, phase:7, title:"Your Day", sub:"Good day · Bad day · Sleepy", aud:"kids",
     phrases:[
       {hu:"Én dolgoztam ma.",pr:"Én dol-goz-tom mo",en:"I worked today."},
@@ -469,8 +475,7 @@ const LESSONS = [
       {hu:"Hány ujjad van?",pr:"Hány uy-yod von",en:"How many fingers do you have?"},
     ], tip:"Count everything: stairs, grapes, toy cars. Use fingers.", pat:"Hány = how many (countable)"},
 
-  // ── PHASE 9: GRAMMAR SPINE ─────────────────────────────────────────────
-  { id:45, phase:9, title:"Definite vs Indefinite Verbs", sub:"Olvasok vs olvasom — when you know which one", aud:"both", patternId:"def-vs-indef",
+  { id:45, phase:5, title:"Reading the Book vs a Book", sub:"Olvasok egy könyvet · olvasom a könyvet", aud:"both", patternId:"def-vs-indef",
     phrases:[
       {hu:"Olvasok egy könyvet.",pr:"Ol-vo-shok edy kön-yet",en:"I'm reading a book."},
       {hu:"Olvasom a könyvet.",pr:"Ol-vo-shom o kön-yet",en:"I'm reading the book."},
@@ -481,7 +486,7 @@ const LESSONS = [
       {hu:"Látok egy madarat.",pr:"Lá-tok edy mo-do-rot",en:"I see a bird."},
       {hu:"Látom a madarat.",pr:"Lá-tom o mo-do-rot",en:"I see the bird."},
     ], tip:"Use 'a/az' before the object to trigger definite conjugation — if you say 'the', the verb ending changes.", pat:"Indefinite: -ok/-ek/-ök (unknown/unspecified)\nDefinite:   -om/-em/-öm (known — 'the')\n\nolvas: olvas-ok  /  olvas-om\neszik: esz-ek    /  esz-em\nkeres: keres-ek  /  keres-em"},
-  { id:46, phase:9, title:"Past Tense — Full Paradigm", sub:"All six persons with csinál", aud:"both", patternId:"past-indef",
+  { id:46, phase:7, title:"What Everyone Did Today", sub:"Csináltam · csináltál · csináltunk", aud:"both", patternId:"past-indef",
     phrases:[
       {hu:"Csináltam.",pr:"Chi-nál-tom",en:"I did it."},
       {hu:"Csináltál valamit?",pr:"Chi-nál-tál vo-lo-mit",en:"Did you do something?"},
@@ -492,18 +497,7 @@ const LESSONS = [
       {hu:"Mit csináltál ma?",pr:"Mit chi-nál-tál mo",en:"What did you do today?"},
       {hu:"Jól csináltad!",pr:"Yól chi-nál-tod",en:"You did it well!"},
     ], tip:"Drill all six forms with csinál, then swap in any regular verb.", pat:"Past -t- + personal ending:\nén:  csinál-t-am\nte:  csinál-t-ál\nő:   csinál-t     (no ending)\nmi:  csinál-t-unk\nti:  csinál-t-atok\nők:  csinál-t-ak"},
-  { id:47, phase:9, title:"Past Tense — Talking About Yesterday", sub:"Mixed verbs, narrative flow", aud:"both", patternId:"past-use",
-    phrases:[
-      {hu:"Tegnap az iskolában voltam.",pr:"Teg-nop oz ish-ko-lá-bon vol-tom",en:"Yesterday I was at school."},
-      {hu:"Mit csináltál tegnap?",pr:"Mit chi-nál-tál teg-nop",en:"What did you do yesterday?"},
-      {hu:"Aludtál egyet?",pr:"O-lud-tál e-dyet",en:"Did you have a nap?"},
-      {hu:"Mentünk a parkba.",pr:"Men-tünk o pork-bo",en:"We went to the park."},
-      {hu:"Ettetek otthon?",pr:"Et-te-tek ot-hon",en:"Did you eat at home?"},
-      {hu:"Megcsináltam a házimat.",pr:"Meg-chi-nál-tom o há-zi-mot",en:"I did my homework."},
-      {hu:"Olvastunk egy könyvet.",pr:"Ol-vosh-tunk edy kön-yet",en:"We read a book."},
-      {hu:"Jól aludtál éjjel?",pr:"Yól o-lud-tál éy-yel",en:"Did you sleep well last night?"},
-    ], tip:"Try telling your child what you did today — past tense becomes natural through narrative.", pat:"Common irregular pasts:\nvan   → volt    |  megy  → ment\nalszik → aludt  |  eszik → evett\nolvas → olvasott|  csinál → csinált"},
-  { id:48, phase:9, title:"Conditional — I Would…", sub:"-nék/-nél/-na and friends", aud:"both", patternId:"conditional",
+  { id:48, phase:4, title:"I Would Like…", sub:"Szeretnék · kérnék · jó lenne", aud:"both", patternId:"conditional",
     phrases:[
       {hu:"Szeretnék fagylaltot.",pr:"Se-ret-nék fody-lol-tot",en:"I would like an ice cream."},
       {hu:"Szeretnél te is?",pr:"Se-ret-nél te ish",en:"Would you like some too?"},
@@ -514,7 +508,7 @@ const LESSONS = [
       {hu:"Jó lenne!",pr:"Yó len-ne",en:"That would be good!"},
       {hu:"Megcsinálnád?",pr:"Meg-chi-nál-nád",en:"Would you do it?"},
     ], tip:"Szeretnék + noun is the polite 'I'd like'. Use it at shops and restaurants too.", pat:"Conditional -ná-/-né- + ending:\nén:  csinál-nék\nte:  csinál-nál\nő:   csinál-na\nmi:  csinál-nánk\nti:  csinál-nátok\nők:  csinál-nának"},
-  { id:49, phase:9, title:"Future with fog", sub:"fogok menni — I'm going to go", aud:"both", patternId:"future-fog",
+  { id:49, phase:1, title:"What We'll Do Today", sub:"Fogok · fogsz · fog · fogunk", aud:"both", patternId:"future-fog",
     phrases:[
       {hu:"Fogok menni.",pr:"Fo-gok men-ni",en:"I'm going to go."},
       {hu:"Fogsz enni?",pr:"Fogsz en-ni",en:"Are you going to eat?"},
@@ -525,7 +519,7 @@ const LESSONS = [
       {hu:"Ma fogunk sütni.",pr:"Mo fo-gunk shüt-ni",en:"Today we're going to bake."},
       {hu:"Holnap fogok takarítani.",pr:"Hol-nop fo-gok to-ko-rí-to-ni",en:"Tomorrow I'm going to clean."},
     ], tip:"fog is always followed by the infinitive (-ni). One helper verb, unlimited futures.", pat:"fog + infinitive (-ni):\nén:  fog-ok\nte:  fog-sz\nő:   fog\nmi:  fog-unk\nti:  fog-tok\nők:  fog-nak"},
-  { id:50, phase:9, title:"Imperative — Asking & Telling", sub:"Gyere! Edd meg! Feküdj le!", aud:"both", patternId:"imperative",
+  { id:50, phase:3, title:"Come Here! Go Back!", sub:"Gyere · menj · edd meg · ne csináld", aud:"both", patternId:"imperative",
     phrases:[
       {hu:"Gyere ide!",pr:"Dye-re i-de",en:"Come here!"},
       {hu:"Menj vissza!",pr:"Meny vis-so",en:"Go back!"},
@@ -536,7 +530,7 @@ const LESSONS = [
       {hu:"Gyerünk!",pr:"Dye-rünk",en:"Let's go!"},
       {hu:"Kérd meg szépen!",pr:"Kérd meg sé-pen",en:"Ask nicely!"},
     ], tip:"Imperatives are the most useful forms for parents — you use them dozens of times a day.", pat:"Imperative: stem + -j- + ending\nenni  → egyél!  |  inni  → igyál!\nmenni → menj!   |  jönni → gyere!\nfeküdni → feküdj!\nNegative: Ne + imperative form"},
-  { id:51, phase:9, title:"My, Your, His — Possessive Suffixes", sub:"könyvem, könyved, könyve…", aud:"both", patternId:"possessive",
+  { id:51, phase:1, title:"Where's Your Shoe?", sub:"Könyvem · cipőd · táskája", aud:"both", patternId:"possessive",
     phrases:[
       {hu:"Ez az én könyvem.",pr:"Ez oz én kön-vem",en:"This is my book."},
       {hu:"Ez a te játékod.",pr:"Ez o te yá-té-kod",en:"This is your toy."},
@@ -547,7 +541,7 @@ const LESSONS = [
       {hu:"Ez a kis szobánk.",pr:"Ez o kish so-bánk",en:"This is our little room."},
       {hu:"Apukád vár rád.",pr:"O-pu-kád vár rád",en:"Your daddy is waiting for you."},
     ], tip:"Try 'Hol van a ...d/ed/öd?' for every lost item hunt.", pat:"Possessive suffixes (one owner):\n1st: könyv-em   my book\n2nd: könyv-ed   your book\n3rd: könyv-e    their book\n1pl: könyv-ünk  our book\n2pl: könyv-etek your (pl) book\n3pl: könyv-ük   their book"},
-  { id:52, phase:9, title:"Giving & Telling — Dative -nak/-nek", sub:"Adok apának · Mondd anyának", aud:"both", patternId:"dative",
+  { id:52, phase:3, title:"Give it to Your Sister", sub:"Add oda testvérednek · mondd apának", aud:"both", patternId:"dative",
     phrases:[
       {hu:"Add oda a testvérednek!",pr:"Od-do o-do o tesht-vé-red-nek",en:"Give it to your sibling!"},
       {hu:"Mondd meg apának!",pr:"Mondd meg o-pá-nok",en:"Tell dad!"},
@@ -558,7 +552,7 @@ const LESSONS = [
       {hu:"Ajándékot hoztam nektek.",pr:"O-yán-dé-kot hoz-tom nek-tek",en:"I brought a gift for you all."},
       {hu:"Szólj a tanárnak!",pr:"Sóly o to-nár-nok",en:"Tell the teacher!"},
     ], tip:"Add -nak/-nek to any name to say 'to/for' them. Personal forms: nekem, neked, neki.", pat:"Dative -nak/-nek = to / for\napa   → apá-nak\nanya  → anyá-nak\nkutya → kutyá-nak\nPersonal:\nén→nekem  te→neked  ő→neki\nmi→nekünk ti→nektek ők→nekik"},
-  { id:53, phase:9, title:"With — Instrumental -val/-vel", sub:"Autóval · késsel · anyával", aud:"both", patternId:"instrumental",
+  { id:53, phase:2, title:"Going Together", sub:"Autóval · veled · anyával", aud:"both", patternId:"instrumental",
     phrases:[
       {hu:"Jövök veled.",pr:"Yö-vök ve-led",en:"I'm coming with you."},
       {hu:"Játssz a testvéreddel!",pr:"Yáts o tesht-vé-red-del",en:"Play with your sibling!"},
@@ -569,7 +563,7 @@ const LESSONS = [
       {hu:"Vágd késsel!",pr:"Vágd kés-sel",en:"Cut it with a knife!"},
       {hu:"Jöttél baráttal?",pr:"Yöt-tél bo-rát-tol",en:"Did you come with a friend?"},
     ], tip:"The suffix assimilates to the final consonant: autóval, but baráttal, késsel.", pat:"Instrumental -val/-vel (assimilates):\nautó  + val → autóval\nkés   + vel → késsel\nanya  + val → anyával\nbarát + tal → baráttal\nPersonal: velem · veled · vele\nvelünk · veletek · velük"},
-  { id:54, phase:9, title:"From — -tól/-ről/-ből", sub:"Three ways to say 'from'", aud:"both", patternId:"from-cases",
+  { id:54, phase:2, title:"Coming Home From…", sub:"Jövök a parkból · leszálltam a bicikliről", aud:"both", patternId:"from-cases",
     phrases:[
       {hu:"Jövök az iskolából.",pr:"Yö-vök oz ish-ko-lá-ból",en:"I'm coming from school."},
       {hu:"Hazajöttem a parkból.",pr:"Ho-zo-yöt-tem o pork-ból",en:"I came home from the park."},
@@ -580,7 +574,7 @@ const LESSONS = [
       {hu:"Kiveszem a fiókból.",pr:"Ki-ve-sem o fi-ók-ból",en:"I take it out of the drawer."},
       {hu:"Elvettem tőle a labdát.",pr:"El-vet-tem tő-le o lob-dát",en:"I took the ball from them."},
     ], tip:"Three different 'from': ból/ből from inside, ról/ről off a surface, tól/től away from nearby.", pat:"Three 'from' cases:\n-ból/-ből  out of (was inside)\n-ról/-ről  off of (was on surface)\n-tól/-től  away from (was beside)\n\niskola  → iskolá-ból\nbicikli → bicikli-ről\napa     → apá-tól"},
-  { id:55, phase:9, title:"Prefixes Compared — be/ki/fel/le/át/vissza", sub:"Same verb, six directions", aud:"both", patternId:"prefixes",
+  { id:55, phase:1, title:"In, Out, Up, Down", sub:"Bemegyek · kimegy · felmegyünk · lemész", aud:"both", patternId:"prefixes",
     phrases:[
       {hu:"Bemegyek a szobába.",pr:"Be-me-dyek o so-bá-bo",en:"I'm going into the room."},
       {hu:"Kimegy az ajtón.",pr:"Ki-medy oz oy-tón",en:"They go out through the door."},
@@ -591,7 +585,7 @@ const LESSONS = [
       {hu:"Bejön hozzánk.",pr:"Be-yön hoz-zánk",en:"They're coming in to us."},
       {hu:"Gyere ki ide!",pr:"Dye-re ki i-de",en:"Come out here!"},
     ], tip:"The prefix separates from the verb when negating: Bemegyek → Nem megyek be.", pat:"Prefixes with megy/jön:\nbe-     into     |  ki-    out of\nfel-    up       |  le-    down\nát-     across   |  vissza- back\n\nWith negation, prefix moves after the verb:\nBemegyek. → Nem megyek be."},
-  { id:56, phase:9, title:"Bigger, Biggest — Comparison", sub:"-bb · leg- · mint", aud:"both", patternId:"comparative",
+  { id:56, phase:3, title:"Bigger, Smaller, Best", sub:"Nagyobb · kisebb · legjobb · mint", aud:"both", patternId:"comparative",
     phrases:[
       {hu:"Ez nagyobb.",pr:"Ez nod-yobb",en:"This is bigger."},
       {hu:"A kék kisebb.",pr:"O kék ki-shebb",en:"The blue one is smaller."},
@@ -1133,7 +1127,7 @@ export default function App(){
     {screen==="home"&&<div>
       {/* Header with goal ring */}
       <div style={{padding:"16px 16px 12px",display:"flex",alignItems:"center",justifyContent:"space-between"}}>
-        <div><div style={{fontSize:24,fontWeight:900,color:C.text,letterSpacing:-0.5}}>Magyar Otthon</div><div style={{fontSize:11,color:C.sub}}>Family Hungarian · 51 lessons</div></div>
+        <div><div style={{fontSize:24,fontWeight:900,color:C.text,letterSpacing:-0.5}}>Magyar Otthon</div><div style={{fontSize:11,color:C.sub}}>Family Hungarian · 55 lessons</div></div>
         <GoalRing todayMins={statsApi.todayMins} goal={statsApi.stats.dailyGoal} onTap={()=>setShowGoalSettings(true)}/>
       </div>
 


### PR DESCRIPTION
Phase 9 "Grammar Spine" packaged 12 paradigm lessons (ids 45–56) behind
their own header, creating a visual grammar corner at odds with the
constitution ("phrase-based lessons organised by daily-life situations…
not academic study"). The content is good but the packaging is not.

Relocate lessons 45–56 into everyday phases with everyday-themed titles
(e.g. "Conditional — I Would…" becomes "I Would Like…" in Food;
"Imperative" becomes "Come Here! Go Back!" in Playing; "Past Tense —
Full Paradigm" becomes "What Everyone Did Today" in End of Day). Merge
lesson 47 into lesson 32 "Their Day" since both cover evening reflection.
Preserve ids, phrase text, tips, pat paradigm tables, and patternId tags
so stats transfer cleanly and follow-up drill-by-pattern specs still
work. Wire relocated lessons into TIME_TAGS so the Daily Focus Engine
surfaces them at natural times of day.

Supersedes the 2026-04-07 decision (grammar-via-curated-lessons.md) with
grammar-dissolved-into-everyday-phases.md.